### PR TITLE
modified: debug.h

### DIFF
--- a/include/debug.h
+++ b/include/debug.h
@@ -36,7 +36,7 @@ extern FILE* log_fp;
       fprintf(stderr, "\33[1;31m"); \
       fprintf(stderr, __VA_ARGS__); \
       fprintf(stderr, "\33[0m\n"); \
-      assert(cond); \
+      assert(0); \
     } \
   } while (0)
 


### PR DESCRIPTION
prevent multi-call if cond contains function call.
Since line 34 make sure that cond is 0.
If cond calls malloc and failed at the first time, but success at the second time, nemu will execute line 35-38 and output error info but do not stop at line 39.